### PR TITLE
allow php 8.x and elasticsearch/elasticsearch 6.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   ],
   "minimum-stability": "RC",
   "require": {
-    "php": "^7.1",
-    "elasticsearch/elasticsearch": "^7.0",
+    "php": "^7.1|^8.0",
+    "elasticsearch/elasticsearch": "^6.0|^7.0",
     "codeception/codeception": "^4.0"
   },
   "autoload": {


### PR DESCRIPTION
I've needed elasticsearch 6.8 compatibility, so I've tested it with `elasticsearch/elasticsearch:^6.0` and its also compatible with php 8.x..